### PR TITLE
Support datatypes

### DIFF
--- a/CalKul/ConsoleUserInterface.cs
+++ b/CalKul/ConsoleUserInterface.cs
@@ -13,7 +13,7 @@ namespace CalKul
             Console.Clear();
         }
 
-        public void WriteStack(Stack<double> stack)
+        public void WriteStack(Stack<object> stack)
         {
             int numRows = 8;
             int counter = numRows;

--- a/CalKul/IArgument.cs
+++ b/CalKul/IArgument.cs
@@ -9,7 +9,7 @@ namespace CalKul
     interface IArgument
     {
         ArgumentType Type { get; }
-        double NumericValue { get; }
+        object NumericValue { get; }
         string StringValue { get; }
     }
 

--- a/CalKul/IUserInterface.cs
+++ b/CalKul/IUserInterface.cs
@@ -8,7 +8,7 @@ namespace CalKul
 {
     interface IUserInterface
     {
-        void WriteStack(Stack<double> stack);
+        void WriteStack(Stack<object> stack);
         void Clear();
     }
 }

--- a/CalKul/Operators/Ceil.cs
+++ b/CalKul/Operators/Ceil.cs
@@ -18,10 +18,10 @@ namespace CalKul
             get { return "ceil"; }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
-            return Math.Ceiling(args.Pop());
+            return Math.Ceiling((double)args.Pop());
         }
     }
 }

--- a/CalKul/Operators/Clear.cs
+++ b/CalKul/Operators/Clear.cs
@@ -22,7 +22,7 @@ namespace CalKul
         {
             OperatorUtils.CheckArgs(args, this);
             args.Clear();
-            return double.MinValue;
+            return null;
         }
     }
 }

--- a/CalKul/Operators/Clear.cs
+++ b/CalKul/Operators/Clear.cs
@@ -18,7 +18,7 @@ namespace CalKul
             get { return "clear"; }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
             args.Clear();

--- a/CalKul/Operators/Cos.cs
+++ b/CalKul/Operators/Cos.cs
@@ -24,10 +24,10 @@ namespace CalKul
             }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
-            return Math.Cos(args.Pop());
+            return Math.Cos((double)args.Pop());
         }
     }
 }

--- a/CalKul/Operators/Div.cs
+++ b/CalKul/Operators/Div.cs
@@ -18,11 +18,11 @@ namespace CalKul
             get { return "/"; }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
-            double subtractor = args.Pop();
-            return args.Pop() / subtractor;
+            object subtractor = args.Pop();
+            return (double)args.Pop() / (double)subtractor;
         }
     }
 }

--- a/CalKul/Operators/Dup.cs
+++ b/CalKul/Operators/Dup.cs
@@ -24,7 +24,7 @@ namespace CalKul
             }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
             var arg = args.Pop();

--- a/CalKul/Operators/Dup2.cs
+++ b/CalKul/Operators/Dup2.cs
@@ -18,7 +18,7 @@ namespace CalKul
             get { return "dup2"; }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
             var arg1 = args.Pop();

--- a/CalKul/Operators/E.cs
+++ b/CalKul/Operators/E.cs
@@ -24,7 +24,7 @@ namespace CalKul
             }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
             return Math.E;

--- a/CalKul/Operators/Floor.cs
+++ b/CalKul/Operators/Floor.cs
@@ -18,10 +18,10 @@ namespace CalKul
             get { return "floor"; }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
-            return Math.Floor(args.Pop());
+            return Math.Floor((double)args.Pop());
         }
     }
 }

--- a/CalKul/Operators/Help.cs
+++ b/CalKul/Operators/Help.cs
@@ -19,7 +19,7 @@ namespace CalKul
             get { return "help"; }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             Console.WriteLine("Available operators:");
             Console.WriteLine("");

--- a/CalKul/Operators/IOperator.cs
+++ b/CalKul/Operators/IOperator.cs
@@ -10,7 +10,8 @@ namespace CalKul
     {
         int NumberOfArguments { get; }
         string OperandName { get; }
-        double Do(Stack<double> args);
-//        void Validate(Stack<double> args);
+        object Do(Stack<object> args);
+//        void Validate(Stack<object> args);
+//      SupportedDatatypes...
     }
 }

--- a/CalKul/Operators/Minus.cs
+++ b/CalKul/Operators/Minus.cs
@@ -24,11 +24,11 @@ namespace CalKul
             }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
-            double subtractor = args.Pop();
-            return args.Pop() - subtractor;
+            object subtractor = args.Pop();
+            return (double)args.Pop() - (double)subtractor;
         }
     }
 }

--- a/CalKul/Operators/Mult.cs
+++ b/CalKul/Operators/Mult.cs
@@ -24,10 +24,10 @@ namespace CalKul
             }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
-            return args.Pop() * args.Pop();
+            return (double)args.Pop() * (double)args.Pop();
         }
     }
 }

--- a/CalKul/Operators/OperatorUtils.cs
+++ b/CalKul/Operators/OperatorUtils.cs
@@ -10,12 +10,42 @@ namespace CalKul
     {
         public static void CheckArgs(Stack<object> args, IOperator op)
         {
-            if (args.Count < op.NumberOfArguments)
+            CheckNumberOfArguments(args, op.NumberOfArguments);
+        }
+
+        internal static bool IsNumeric(Stack<object> args, int numberOfArguments)
+        {
+            CheckNumberOfArguments(args, numberOfArguments);
+            return IsOfType(args, numberOfArguments, typeof(double));
+        }
+
+        internal static bool IsString(Stack<object> args, int numberOfArguments)
+        {
+            CheckNumberOfArguments(args, numberOfArguments);
+            return IsOfType(args, numberOfArguments, typeof(string));
+        }
+
+        internal static bool IsOfType(Stack<object> args, int numberOfArguments, Type type)
+        {
+            bool allIsTypable = true;
+            var stackArr = args.ToArray();
+            for (int i = 0; i < numberOfArguments; i++)
+            {
+                if (stackArr[i].GetType() != type)
+                {
+                    allIsTypable = false;
+                }
+            }
+            return allIsTypable;
+        }
+
+        internal static void CheckNumberOfArguments(Stack<object> args, int numberOfArguments)
+        {
+            if (args.Count < numberOfArguments)
             {
                 throw new ArgumentException("Wrong number of arguments");
             }
-
-
         }
+
     }
 }

--- a/CalKul/Operators/OperatorUtils.cs
+++ b/CalKul/Operators/OperatorUtils.cs
@@ -8,12 +8,14 @@ namespace CalKul
 {
     public static class OperatorUtils
     {
-        public static void CheckArgs(Stack<double> args, IOperator op)
+        public static void CheckArgs(Stack<object> args, IOperator op)
         {
             if (args.Count < op.NumberOfArguments)
             {
                 throw new ArgumentException("Wrong number of arguments");
             }
+
+
         }
     }
 }

--- a/CalKul/Operators/Pi.cs
+++ b/CalKul/Operators/Pi.cs
@@ -21,7 +21,7 @@ namespace CalKul
             get { return "pi"; }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
             return Math.PI;

--- a/CalKul/Operators/Plus.cs
+++ b/CalKul/Operators/Plus.cs
@@ -24,10 +24,10 @@ namespace CalKul
             }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
-            return args.Pop() + args.Pop();
+            return (double)args.Pop() + (double)args.Pop();
         }
     }
 }

--- a/CalKul/Operators/Plus.cs
+++ b/CalKul/Operators/Plus.cs
@@ -27,7 +27,19 @@ namespace CalKul
         public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
-            return (double)args.Pop() + (double)args.Pop();
+            if (OperatorUtils.IsNumeric(args, this.NumberOfArguments))
+            {
+                return (double)args.Pop() + (double)args.Pop();
+            }
+            else if (OperatorUtils.IsString(args, this.NumberOfArguments))
+            {
+                StringBuilder sb = new StringBuilder((string)args.Pop());
+                return sb.Append((string)args.Pop());
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 }

--- a/CalKul/Operators/Sin.cs
+++ b/CalKul/Operators/Sin.cs
@@ -24,10 +24,10 @@ namespace CalKul
             }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
-            return Math.Sin(args.Pop());
+            return Math.Sin((double)args.Pop());
         }
     }
 }

--- a/CalKul/Operators/Sqr.cs
+++ b/CalKul/Operators/Sqr.cs
@@ -24,10 +24,10 @@ namespace CalKul
             }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
-            var value = args.Pop();
+            var value = (double)args.Pop();
             return value * value;
         }
     }

--- a/CalKul/Operators/Swap.cs
+++ b/CalKul/Operators/Swap.cs
@@ -24,7 +24,7 @@ namespace CalKul
             }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
             var arg1 = args.Pop();

--- a/CalKul/Operators/Tan.cs
+++ b/CalKul/Operators/Tan.cs
@@ -24,10 +24,10 @@ namespace CalKul
             }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
-            return Math.Tan(args.Pop());
+            return Math.Tan((double)args.Pop());
         }
     }
 }

--- a/CalKul/Operators/drop.cs
+++ b/CalKul/Operators/drop.cs
@@ -28,7 +28,7 @@ namespace CalKul
         {
             OperatorUtils.CheckArgs(args, this);
             args.Pop();
-            return double.MinValue;
+            return null;
         }
     }
 }

--- a/CalKul/Operators/drop.cs
+++ b/CalKul/Operators/drop.cs
@@ -24,7 +24,7 @@ namespace CalKul
             }
         }
 
-        public double Do(Stack<double> args)
+        public object Do(Stack<object> args)
         {
             OperatorUtils.CheckArgs(args, this);
             args.Pop();

--- a/CalKul/Parser.cs
+++ b/CalKul/Parser.cs
@@ -14,7 +14,7 @@ namespace CalKul
         {
         }
 
-        public void ParseDo(string input, Stack<double> stack)
+        public void ParseDo(string input, Stack<object> stack)
         {
             double number;
             if (double.TryParse(input, out number))
@@ -35,10 +35,10 @@ namespace CalKul
                     if (input == op.OperandName)
                     {
                         var retVal = op.Do(stack);
-                        if (retVal != double.MinValue)
-                        {
+                        //if (retVal != double.MinValue)
+                        //{
                             stack.Push(retVal);
-                        }
+                        //}
                     }
                 }
             }

--- a/CalKul/Parser.cs
+++ b/CalKul/Parser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 namespace CalKul
 {
@@ -16,10 +17,9 @@ namespace CalKul
 
         public void ParseDo(string input, Stack<object> stack)
         {
-            double number;
-            if (double.TryParse(input, out number))
+            if (ParseArgumentAndPutOnStack(input, stack))
             {
-                stack.Push(number);
+                
             }
             else if (input.Contains(" "))
             {
@@ -35,12 +35,31 @@ namespace CalKul
                     if (input == op.OperandName)
                     {
                         var retVal = op.Do(stack);
-                        //if (retVal != double.MinValue)
-                        //{
+                        if (retVal != null)
+                        {
                             stack.Push(retVal);
-                        //}
+                        }
                     }
                 }
+            }
+        }
+
+        private bool ParseArgumentAndPutOnStack(string input, Stack<object> stack)
+        {
+            double doubleArg;
+            if (double.TryParse(input, out doubleArg))
+            {
+                stack.Push(doubleArg);
+                return true;
+            }
+            else if (input.StartsWith("\"") && input.EndsWith("\""))
+            {
+                stack.Push(Regex.Replace(input, "\"",""));
+                return true;
+            }
+            else
+            {
+                return false;
             }
         }
     }

--- a/CalKul/Program.cs
+++ b/CalKul/Program.cs
@@ -15,20 +15,20 @@ namespace CalKul
 
         static void Main(string[] args)
         {
-            Stack<double> doubleStack = new Stack<double>();
+            Stack<object> objectStack = new Stack<object>();
             string input = "";
 
             parser = new Parser();
             RegisterDependencies();
             AutoregisterOperators();
 
-            userInterface.WriteStack(doubleStack);
+            userInterface.WriteStack(objectStack);
             while ((input = Console.ReadLine()) != "quit")
             {
                 try
                 {
-                    parser.ParseDo(input, doubleStack);
-                    userInterface.WriteStack(doubleStack);
+                    parser.ParseDo(input, objectStack);
+                    userInterface.WriteStack(objectStack);
                 } catch (Exception exp)
                 {
                     Console.WriteLine("Error: " + exp.Message);

--- a/UnitTests/AddTest.cs
+++ b/UnitTests/AddTest.cs
@@ -16,13 +16,13 @@ namespace UnitTests
         public void TooFewArgs()
         {
             plus = new Plus();
-            plus.Do(new Stack<double>());
+            plus.Do(new Stack<object>());
         }
 
         [TestMethod]
         public void TwoArgsAdds()
         {
-            var stack = new Stack<double>();
+            var stack = new Stack<object>();
             stack.Push(2);
             stack.Push(3);
             plus = new Plus();

--- a/UnitTests/SwapTest.cs
+++ b/UnitTests/SwapTest.cs
@@ -16,14 +16,14 @@ namespace UnitTests
         public void TooFewArgs()
         {
             swap = new Swap();
-            swap.Do(new Stack<double>());
+            swap.Do(new Stack<object>());
         }
 
         [TestMethod]
         public void SwapSwaps()
         {
             swap = new Swap();
-            var stack = new Stack<double>();
+            var stack = new Stack<object>();
             stack.Push(1);
             stack.Push(2);
             Assert.AreEqual(1, swap.Do(stack));


### PR DESCRIPTION
The CalKul is now based on a Stack<object> instead of a Stack<double>. I've also added some static helper methods to the OperatorUtils class so that the operators can check for type and apply the right operation depending on what's on the stack. Plus operator now works with string and double as a first test.

No unit tests added. This should really be done, but it can wait for a while. Later this evening perhaps.